### PR TITLE
Fix NullPointerException with the "host" parameter.

### DIFF
--- a/changelogs/0.5.3.md
+++ b/changelogs/0.5.3.md
@@ -1,0 +1,3 @@
+## Changes
+
+- Fix crash with a NullPointerException on Windows

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@
 org.gradle.jvmargs=-Xmx3G
 
 # Mod properties
-mod.version=0.5.2
+mod.version=0.5.3

--- a/src/main/java/io/github/gaming32/worldhost/origincheck/OriginCheckers.java
+++ b/src/main/java/io/github/gaming32/worldhost/origincheck/OriginCheckers.java
@@ -49,6 +49,7 @@ public class OriginCheckers {
     }
 
     public static boolean hasStandardOrigin(URI uri) {
+        if (uri==null) return false;
         return isStandardHost(uri.getHost());
     }
 

--- a/src/main/java/io/github/gaming32/worldhost/origincheck/OriginCheckers.java
+++ b/src/main/java/io/github/gaming32/worldhost/origincheck/OriginCheckers.java
@@ -33,6 +33,7 @@ public class OriginCheckers {
     );
 
     public static boolean isStandardHost(String host) {
+        if (host==null) return false;
         final var hostLength = host.length();
         for (final var origin : STANDARD_ORIGINS) {
             if (host.equals(origin)) {

--- a/src/main/java/io/github/gaming32/worldhost/origincheck/OriginCheckers.java
+++ b/src/main/java/io/github/gaming32/worldhost/origincheck/OriginCheckers.java
@@ -49,7 +49,6 @@ public class OriginCheckers {
     }
 
     public static boolean hasStandardOrigin(URI uri) {
-        if (uri==null) return false;
         return isStandardHost(uri.getHost());
     }
 

--- a/src/main/java/io/github/gaming32/worldhost/origincheck/checker/AbstractOriginChecker.java
+++ b/src/main/java/io/github/gaming32/worldhost/origincheck/checker/AbstractOriginChecker.java
@@ -58,12 +58,18 @@ abstract class AbstractOriginChecker implements OriginChecker {
     private List<URI> toUriList(List<@Nullable String> uris) {
         final var result = new ArrayList<URI>(uris.size());
         for (final var url : uris) {
-            if (url != null && !url.isEmpty()) {
-                try {
-                    result.add(new URI(url));
-                } catch (URISyntaxException e) {
-                    WorldHost.LOGGER.warn("Failed to parse {} URL {}", getOriginAttributeName(), url, e);
+            try{
+                if (url == null || url.isEmpty()) {
+                    result.add(new URI("https://example.com/"));
+                }else{
+                    result.add(new URI("about:blank"));
+                    WorldHost.LOGGER.warn("Failed to parse {} URL {}", getOriginAttributeName(), url);
                 }
+            }catch (URISyntaxException e) {
+                try {
+                    result.add(new URI("about:blank"));
+                } catch (URISyntaxException ignored) {}
+                WorldHost.LOGGER.warn("Failed to parse {} URL {}", getOriginAttributeName(), url, e);
             }
         }
         return result;

--- a/src/main/java/io/github/gaming32/worldhost/origincheck/checker/AbstractOriginChecker.java
+++ b/src/main/java/io/github/gaming32/worldhost/origincheck/checker/AbstractOriginChecker.java
@@ -58,7 +58,7 @@ abstract class AbstractOriginChecker implements OriginChecker {
     private List<URI> toUriList(List<@Nullable String> uris) {
         final var result = new ArrayList<URI>(uris.size());
         for (final var url : uris) {
-            if (url != null) {
+            if (url != null && !url.isEmpty()) {
                 try {
                     result.add(new URI(url));
                 } catch (URISyntaxException e) {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -244,7 +244,7 @@ dependencies {
     }
 
     if (mcVersion >= 1_20_04 && isFabric) {
-        modCompileOnly("de.florianmichael:viafabricplus:3.0.2") {
+        modCompileOnly("maven.modrinth:viafabricplus:3.0.2") {
             isTransitive = false
         }
     }
@@ -312,7 +312,7 @@ modrinth {
         1_21_03 -> "1.21.2"
         else -> null
     }?.let(gameVersions::add)
-    loaders.add(this@Version_gradle.loaderName)
+    loaders.add(loaderName)
     dependencies {
         if (isFabric) {
             optional.project("modmenu")


### PR DESCRIPTION
This should fix a launch crash reported in the discord server, changes:
* Fixied the array "host" being able to contain a null string with certain metadata.
* Add checks to prevent a crash if the "host" array contains null pointer.
* Fix build error caused by a change to viaversion's maven.
* Changed ``this@Version_gradle.loaderName`` to ``loaderName``.